### PR TITLE
完善数据库结构并添加测试数据

### DIFF
--- a/exam.sql
+++ b/exam.sql
@@ -21,9 +21,9 @@ SET FOREIGN_KEY_CHECKS=0;
 DROP TABLE IF EXISTS `admin`;
 CREATE TABLE `admin` (
   `Ano` varchar(20) NOT NULL COMMENT '管理员账号',
-  `Apassword` varchar(20) NOT NULL COMMENT '管理员密码',
+  `Apassword` varchar(32) NOT NULL COMMENT '管理员密码',
   PRIMARY KEY (`Ano`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for course
@@ -32,14 +32,14 @@ DROP TABLE IF EXISTS `course`;
 CREATE TABLE `course` (
   `Cno` varchar(20) NOT NULL COMMENT '课程编号',
   `Cname` varchar(20) NOT NULL COMMENT '课程名称',
-  `Subno` varchar(20) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL COMMENT '课程所属科目',
+  `Subno` varchar(5) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '课程所属科目',
   `Mno` varchar(20) DEFAULT NULL COMMENT '教授该课程教师号',
   PRIMARY KEY (`Cno`),
   KEY `Mno` (`Mno`),
   KEY `Subno` (`Subno`),
   CONSTRAINT `course_ibfk_1` FOREIGN KEY (`Mno`) REFERENCES `mentor` (`Mno`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `course_ibfk_2` FOREIGN KEY (`Subno`) REFERENCES `subject` (`Subno`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for mentor
@@ -50,9 +50,9 @@ CREATE TABLE `mentor` (
   `Mname` varchar(10) NOT NULL COMMENT '教师姓名',
   `Mgender` varchar(3) DEFAULT NULL COMMENT '教师性别',
   `Mtitle` varchar(10) DEFAULT NULL COMMENT '教师职称',
-  `Mpassword` varchar(20) NOT NULL COMMENT '教师登陆密码',
+  `Mpassword` varchar(32) NOT NULL COMMENT '教师登陆密码',
   PRIMARY KEY (`Mno`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for paper
@@ -63,11 +63,11 @@ CREATE TABLE `paper` (
   `Pname` varchar(30) DEFAULT NULL COMMENT '试卷名',
   `Preference` int DEFAULT '0' COMMENT '试卷被引用的次数',
   `Pisdeleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT '真：隐藏 假：显示',
-  `Subno` varchar(20) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL COMMENT '科目编号',
+  `Subno` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '科目编号',
   PRIMARY KEY (`Pno`),
   KEY `Subno` (`Subno`),
   CONSTRAINT `paper_ibfk_1` FOREIGN KEY (`Subno`) REFERENCES `subject` (`Subno`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for question
@@ -75,17 +75,17 @@ CREATE TABLE `paper` (
 DROP TABLE IF EXISTS `question`;
 CREATE TABLE `question` (
   `Qno` varchar(20) NOT NULL COMMENT '题库中的编号',
-  `Qtype` tinyint(1) NOT NULL COMMENT '题目类型',
+  `Qtype` enum('select', 'multi', 'fill') NOT NULL COMMENT '题目类型 select-单选 multi-多选 fill-填空',
   `Qstem` varchar(255) NOT NULL COMMENT '题目的内容',
-  `Qanswer` varchar(255) NOT NULL COMMENT '题目的正确答案，由字典转化的字符串',
-  `Qselect` tinyint(1) DEFAULT NULL COMMENT '选择题的正确选项',
-  `Subno` varchar(25) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL COMMENT '题目所属的科目',
+  `Qanswer` varchar(255) NOT NULL COMMENT 'JSON格式的题目的答案，选择题的备选项，填空题的答案',
+  `Qselect` varchar(10) DEFAULT NULL COMMENT '选择题的正确选项',
+  `Subno` varchar(5) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '题目所属的科目',
   `Qreference` int unsigned NOT NULL DEFAULT '0' COMMENT '题目被引用的次数',
   `Qisdeleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT '真：隐藏 假：显示',
   PRIMARY KEY (`Qno`),
   KEY `Subno` (`Subno`),
   CONSTRAINT `question_ibfk_1` FOREIGN KEY (`Subno`) REFERENCES `subject` (`Subno`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for question_paper
@@ -100,7 +100,7 @@ CREATE TABLE `question_paper` (
   KEY `Qno` (`Qno`),
   CONSTRAINT `question_paper_ibfk_1` FOREIGN KEY (`Pno`) REFERENCES `paper` (`Pno`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `question_paper_ibfk_2` FOREIGN KEY (`Qno`) REFERENCES `question` (`Qno`) ON DELETE RESTRICT ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for student
@@ -109,11 +109,11 @@ DROP TABLE IF EXISTS `student`;
 CREATE TABLE `student` (
   `Sno` varchar(20) NOT NULL COMMENT '学生编号',
   `Sname` varchar(10) NOT NULL COMMENT '学生姓名',
-  `Sgender` varchar(3) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL COMMENT '学生性别',
+  `Sgender` enum('男','女') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '学生性别',
   `Smajor` varchar(20) DEFAULT NULL COMMENT '学生专业',
-  `Spassword` varchar(20) NOT NULL COMMENT '学生登陆密码',
+  `Spassword` varchar(32) NOT NULL COMMENT '学生登陆密码',
   PRIMARY KEY (`Sno`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for student_course
@@ -126,7 +126,7 @@ CREATE TABLE `student_course` (
   KEY `student_course_ibfk_2` (`Sno`),
   CONSTRAINT `student_course_ibfk_1` FOREIGN KEY (`Cno`) REFERENCES `course` (`Cno`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `student_course_ibfk_2` FOREIGN KEY (`Sno`) REFERENCES `student` (`Sno`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for student_test
@@ -140,17 +140,17 @@ CREATE TABLE `student_test` (
   KEY `Sno` (`Sno`),
   CONSTRAINT `student_test_ibfk_1` FOREIGN KEY (`Tno`) REFERENCES `test` (`Tno`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `student_test_ibfk_2` FOREIGN KEY (`Sno`) REFERENCES `student` (`Sno`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for subject
 -- ----------------------------
 DROP TABLE IF EXISTS `subject`;
 CREATE TABLE `subject` (
-  `Subno` varchar(20) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT '科目编号',
-  `Subname` varchar(25) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT '科目名称',
+  `Subno` varchar(5) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT '科目编号',
+  `Subname` varchar(25) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT '科目名称',
   PRIMARY KEY (`Subno`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for test
@@ -158,14 +158,14 @@ CREATE TABLE `subject` (
 DROP TABLE IF EXISTS `test`;
 CREATE TABLE `test` (
   `Tno` char(20) NOT NULL COMMENT '考试的编号',
-  `Tname` varchar(20) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT '考试的名称',
+  `Tname` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT '考试的名称',
   `Tstart` timestamp NOT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '考试开始时间',
   `Tend` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '考试结束时间',
   `Pno` varchar(20) DEFAULT NULL COMMENT '引用的试卷编号',
-  `Cno` varchar(20) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL COMMENT '所属的课程编号',
+  `Cno` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '所属的课程编号',
   PRIMARY KEY (`Tno`),
   KEY `Pno` (`Pno`),
   KEY `Cno` (`Cno`),
   CONSTRAINT `test_ibfk_1` FOREIGN KEY (`Pno`) REFERENCES `paper` (`Pno`) ON DELETE RESTRICT ON UPDATE CASCADE,
   CONSTRAINT `test_ibfk_2` FOREIGN KEY (`Cno`) REFERENCES `course` (`Cno`) ON DELETE RESTRICT ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;

--- a/exam.sql
+++ b/exam.sql
@@ -1,0 +1,171 @@
+/*
+Navicat MySQL Data Transfer
+
+Source Server         : localhost
+Source Server Version : 80021
+Source Host           : 127.0.0.1:3306
+Source Database       : exam
+
+Target Server Type    : MYSQL
+Target Server Version : 80021
+File Encoding         : 65001
+
+Date: 2020-12-15 10:59:31
+*/
+
+SET FOREIGN_KEY_CHECKS=0;
+
+-- ----------------------------
+-- Table structure for admin
+-- ----------------------------
+DROP TABLE IF EXISTS `admin`;
+CREATE TABLE `admin` (
+  `Ano` varchar(20) NOT NULL COMMENT '管理员账号',
+  `Apassword` varchar(20) NOT NULL COMMENT '管理员密码',
+  PRIMARY KEY (`Ano`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- ----------------------------
+-- Table structure for course
+-- ----------------------------
+DROP TABLE IF EXISTS `course`;
+CREATE TABLE `course` (
+  `Cno` varchar(20) NOT NULL COMMENT '课程编号',
+  `Cname` varchar(20) NOT NULL COMMENT '课程名称',
+  `Subno` varchar(20) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL COMMENT '课程所属科目',
+  `Mno` varchar(20) DEFAULT NULL COMMENT '教授该课程教师号',
+  PRIMARY KEY (`Cno`),
+  KEY `Mno` (`Mno`),
+  KEY `Subno` (`Subno`),
+  CONSTRAINT `course_ibfk_1` FOREIGN KEY (`Mno`) REFERENCES `mentor` (`Mno`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `course_ibfk_2` FOREIGN KEY (`Subno`) REFERENCES `subject` (`Subno`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- ----------------------------
+-- Table structure for mentor
+-- ----------------------------
+DROP TABLE IF EXISTS `mentor`;
+CREATE TABLE `mentor` (
+  `Mno` varchar(20) NOT NULL COMMENT '教师编号',
+  `Mname` varchar(10) NOT NULL COMMENT '教师姓名',
+  `Mgender` varchar(3) DEFAULT NULL COMMENT '教师性别',
+  `Mtitle` varchar(10) DEFAULT NULL COMMENT '教师职称',
+  `Mpassword` varchar(20) NOT NULL COMMENT '教师登陆密码',
+  PRIMARY KEY (`Mno`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- ----------------------------
+-- Table structure for paper
+-- ----------------------------
+DROP TABLE IF EXISTS `paper`;
+CREATE TABLE `paper` (
+  `Pno` varchar(20) NOT NULL COMMENT '试卷的编号',
+  `Pname` varchar(30) DEFAULT NULL COMMENT '试卷名',
+  `Preference` int DEFAULT '0' COMMENT '试卷被引用的次数',
+  `Pisdeleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT '真：隐藏 假：显示',
+  `Subno` varchar(20) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL COMMENT '科目编号',
+  PRIMARY KEY (`Pno`),
+  KEY `Subno` (`Subno`),
+  CONSTRAINT `paper_ibfk_1` FOREIGN KEY (`Subno`) REFERENCES `subject` (`Subno`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- ----------------------------
+-- Table structure for question
+-- ----------------------------
+DROP TABLE IF EXISTS `question`;
+CREATE TABLE `question` (
+  `Qno` varchar(20) NOT NULL COMMENT '题库中的编号',
+  `Qtype` tinyint(1) NOT NULL COMMENT '题目类型',
+  `Qstem` varchar(255) NOT NULL COMMENT '题目的内容',
+  `Qanswer` varchar(255) NOT NULL COMMENT '题目的正确答案，由字典转化的字符串',
+  `Qselect` tinyint(1) DEFAULT NULL COMMENT '选择题的正确选项',
+  `Subno` varchar(25) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL COMMENT '题目所属的科目',
+  `Qreference` int unsigned NOT NULL DEFAULT '0' COMMENT '题目被引用的次数',
+  `Qisdeleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT '真：隐藏 假：显示',
+  PRIMARY KEY (`Qno`),
+  KEY `Subno` (`Subno`),
+  CONSTRAINT `question_ibfk_1` FOREIGN KEY (`Subno`) REFERENCES `subject` (`Subno`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- ----------------------------
+-- Table structure for question_paper
+-- ----------------------------
+DROP TABLE IF EXISTS `question_paper`;
+CREATE TABLE `question_paper` (
+  `Pno` varchar(20) NOT NULL COMMENT '题库中的编号',
+  `Qno` varchar(20) NOT NULL COMMENT '试卷的编号',
+  `QPscore` int DEFAULT '0' COMMENT '试题的分值',
+  `QPposition` int DEFAULT NULL COMMENT '题目在试卷中的位置',
+  PRIMARY KEY (`Pno`,`Qno`),
+  KEY `Qno` (`Qno`),
+  CONSTRAINT `question_paper_ibfk_1` FOREIGN KEY (`Pno`) REFERENCES `paper` (`Pno`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `question_paper_ibfk_2` FOREIGN KEY (`Qno`) REFERENCES `question` (`Qno`) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- ----------------------------
+-- Table structure for student
+-- ----------------------------
+DROP TABLE IF EXISTS `student`;
+CREATE TABLE `student` (
+  `Sno` varchar(20) NOT NULL COMMENT '学生编号',
+  `Sname` varchar(10) NOT NULL COMMENT '学生姓名',
+  `Sgender` varchar(3) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL COMMENT '学生性别',
+  `Smajor` varchar(20) DEFAULT NULL COMMENT '学生专业',
+  `Spassword` varchar(20) NOT NULL COMMENT '学生登陆密码',
+  PRIMARY KEY (`Sno`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- ----------------------------
+-- Table structure for student_course
+-- ----------------------------
+DROP TABLE IF EXISTS `student_course`;
+CREATE TABLE `student_course` (
+  `Cno` varchar(20) NOT NULL COMMENT '课程编号',
+  `Sno` varchar(20) NOT NULL COMMENT '学生编号',
+  PRIMARY KEY (`Cno`,`Sno`),
+  KEY `student_course_ibfk_2` (`Sno`),
+  CONSTRAINT `student_course_ibfk_1` FOREIGN KEY (`Cno`) REFERENCES `course` (`Cno`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `student_course_ibfk_2` FOREIGN KEY (`Sno`) REFERENCES `student` (`Sno`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- ----------------------------
+-- Table structure for student_test
+-- ----------------------------
+DROP TABLE IF EXISTS `student_test`;
+CREATE TABLE `student_test` (
+  `Tno` varchar(20) NOT NULL COMMENT '考试编号',
+  `Sno` varchar(20) NOT NULL COMMENT '学生编号',
+  `STgrade` int DEFAULT NULL COMMENT '学生考试成绩',
+  PRIMARY KEY (`Tno`,`Sno`),
+  KEY `Sno` (`Sno`),
+  CONSTRAINT `student_test_ibfk_1` FOREIGN KEY (`Tno`) REFERENCES `test` (`Tno`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `student_test_ibfk_2` FOREIGN KEY (`Sno`) REFERENCES `student` (`Sno`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- ----------------------------
+-- Table structure for subject
+-- ----------------------------
+DROP TABLE IF EXISTS `subject`;
+CREATE TABLE `subject` (
+  `Subno` varchar(20) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT '科目编号',
+  `Subname` varchar(25) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT '科目名称',
+  PRIMARY KEY (`Subno`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- ----------------------------
+-- Table structure for test
+-- ----------------------------
+DROP TABLE IF EXISTS `test`;
+CREATE TABLE `test` (
+  `Tno` char(20) NOT NULL COMMENT '考试的编号',
+  `Tname` varchar(20) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT '考试的名称',
+  `Tstart` timestamp NOT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '考试开始时间',
+  `Tend` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '考试结束时间',
+  `Pno` varchar(20) DEFAULT NULL COMMENT '引用的试卷编号',
+  `Cno` varchar(20) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL COMMENT '所属的课程编号',
+  PRIMARY KEY (`Tno`),
+  KEY `Pno` (`Pno`),
+  KEY `Cno` (`Cno`),
+  CONSTRAINT `test_ibfk_1` FOREIGN KEY (`Pno`) REFERENCES `paper` (`Pno`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT `test_ibfk_2` FOREIGN KEY (`Cno`) REFERENCES `course` (`Cno`) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/sql/data.sql
+++ b/sql/data.sql
@@ -1,0 +1,62 @@
+INSERT INTO `admin`(`Ano`, `Apassword`) VALUES ('admin', '123456');
+INSERT INTO `admin`(`Ano`, `Apassword`) VALUES ('admin_en', 'e10adc3949ba59abbe56e057f20f883e');
+
+INSERT INTO `mentor`(`Mno`, `Mname`, `Mgender`, `Mtitle`, `Mpassword`) VALUES ('teacher1', '张三', '男', '副教授', '123456');
+INSERT INTO `mentor`(`Mno`, `Mname`, `Mgender`, `Mtitle`, `Mpassword`) VALUES ('teacher1_en', '张三', '男', '副教授', 'e10adc3949ba59abbe56e057f20f883e');
+INSERT INTO `mentor`(`Mno`, `Mname`, `Mgender`, `Mtitle`, `Mpassword`) VALUES ('teacher2', '李四', '女', '教授', '123456');
+INSERT INTO `mentor`(`Mno`, `Mname`, `Mgender`, `Mtitle`, `Mpassword`) VALUES ('teacher2_en', '李四', '女', '教授', 'e10adc3949ba59abbe56e057f20f883e');
+INSERT INTO `mentor`(`Mno`, `Mname`, `Mgender`, `Mtitle`, `Mpassword`) VALUES ('teacher3', 'Peter', '男', '讲师', '123456');
+INSERT INTO `mentor`(`Mno`, `Mname`, `Mgender`, `Mtitle`, `Mpassword`) VALUES ('teacher3_en', 'Peter', '男', '讲师', 'e10adc3949ba59abbe56e057f20f883e');
+
+INSERT INTO `student`(`Sno`, `Sname`, `Sgender`, `Smajor`, `Spassword`) VALUES ('student1', '李明', '男', '软件工程', '123456');
+INSERT INTO `student`(`Sno`, `Sname`, `Sgender`, `Smajor`, `Spassword`) VALUES ('student1_en', '李明', '男', '软件工程', 'e10adc3949ba59abbe56e057f20f883e');
+INSERT INTO `student`(`Sno`, `Sname`, `Sgender`, `Smajor`, `Spassword`) VALUES ('student2', 'Mary', '女', '信息安全', '123456');
+INSERT INTO `student`(`Sno`, `Sname`, `Sgender`, `Smajor`, `Spassword`) VALUES ('student2_en', 'Mary', '女', '信息安全', 'e10adc3949ba59abbe56e057f20f883e');
+INSERT INTO `student`(`Sno`, `Sname`, `Sgender`, `Smajor`, `Spassword`) VALUES ('student3', '王丽', '女', '软件工程', '123456');
+INSERT INTO `student`(`Sno`, `Sname`, `Sgender`, `Smajor`, `Spassword`) VALUES ('student3_en', '王丽', '女', '软件工程', 'e10adc3949ba59abbe56e057f20f883e');
+INSERT INTO `student`(`Sno`, `Sname`, `Sgender`, `Smajor`, `Spassword`) VALUES ('student4', 'Антон', '男', '核工程', '123456');
+INSERT INTO `student`(`Sno`, `Sname`, `Sgender`, `Smajor`, `Spassword`) VALUES ('student4_en', 'Антон', '男', '核工程', 'e10adc3949ba59abbe56e057f20f883e');
+
+INSERT INTO `subject`(`Subno`, `Subname`) VALUES ('s0001', '软件工程');
+INSERT INTO `subject`(`Subno`, `Subname`) VALUES ('s0002', '数据库原理');
+INSERT INTO `subject`(`Subno`, `Subname`) VALUES ('s0003', '编译原理');
+INSERT INTO `subject`(`Subno`, `Subname`) VALUES ('s0004', '流体力学');
+INSERT INTO `subject`(`Subno`, `Subname`) VALUES ('s0005', '工程热力学');
+INSERT INTO `subject`(`Subno`, `Subname`) VALUES ('s0006', 'C语言程序设计');
+INSERT INTO `subject`(`Subno`, `Subname`) VALUES ('s0007', 'Java高级语言程序设计');
+
+INSERT INTO `course`(`Cno`, `Cname`, `Subno`, `Mno`) VALUES ('c0001', '数据库教学班1', 's0002', 'teacher1');
+INSERT INTO `course`(`Cno`, `Cname`, `Subno`, `Mno`) VALUES ('c0002', '数据库教学班2', 's0002', 'teacher1');
+INSERT INTO `course`(`Cno`, `Cname`, `Subno`, `Mno`) VALUES ('c0003', '数据库教学班3', 's0002', 'teacher1_en');
+INSERT INTO `course`(`Cno`, `Cname`, `Subno`, `Mno`) VALUES ('c0004', '流体力学1', 's0004', 'teacher2');
+INSERT INTO `course`(`Cno`, `Cname`, `Subno`, `Mno`) VALUES ('c0005', '流体力学2', 's0004', 'teacher2_en');
+
+INSERT INTO `paper`(`Pno`, `Pname`, `Preference`, `Pisdeleted`, `Subno`) VALUES ('p0001', '数据库基础卷', 0, 0, 's0002');
+INSERT INTO `paper`(`Pno`, `Pname`, `Preference`, `Pisdeleted`, `Subno`) VALUES ('p0002', '数据库提高卷', 0, 0, 's0002');
+INSERT INTO `paper`(`Pno`, `Pname`, `Preference`, `Pisdeleted`, `Subno`) VALUES ('p0003', '流体力学基础卷', 0, 1, 's0004');
+INSERT INTO `paper`(`Pno`, `Pname`, `Preference`, `Pisdeleted`, `Subno`) VALUES ('p0004', '软件工程提高卷', 0, 0, 's0001');
+
+INSERT INTO `question`(`Qno`, `Qtype`, `Qstem`, `Qanswer`, `Qselect`, `Subno`, `Qreference`, `Qisdeleted`) VALUES ('q00001', 'select', '这是一道数据库单选题()', '{\"A\": \"我是A\", \"B\": \"我是B\", \"C\": \"我是C\". \"D\": \"我是D\"}', 'A', 's0002', 0, 1);
+INSERT INTO `question`(`Qno`, `Qtype`, `Qstem`, `Qanswer`, `Qselect`, `Subno`, `Qreference`, `Qisdeleted`) VALUES ('q00002', 'multi', '这是一道流体力学多选题()', '{\"A\": \"我是A\", \"B\": \"我是B\", \"C\": \"我是C\". \"D\": \"我是D\", \"E\": \"我是E\"}', 'ABC', 's0001', 0, 0);
+INSERT INTO `question`(`Qno`, `Qtype`, `Qstem`, `Qanswer`, `Qselect`, `Subno`, `Qreference`, `Qisdeleted`) VALUES ('q00003', 'fill', '这是一道[填空]填空[填空]', '{\"A\": \"编译原理\", \"B\": \"题\"}', NULL, 's0003', 0, 0);
+
+INSERT INTO `question_paper`(`Pno`, `Qno`, `QPscore`, `QPposition`) VALUES ('p0001', 'q00001', 2, 1);
+INSERT INTO `question_paper`(`Pno`, `Qno`, `QPscore`, `QPposition`) VALUES ('p0001', 'q00002', 10, 3);
+INSERT INTO `question_paper`(`Pno`, `Qno`, `QPscore`, `QPposition`) VALUES ('p0001', 'q00003', 5, 2);
+INSERT INTO `question_paper`(`Pno`, `Qno`, `QPscore`, `QPposition`) VALUES ('p0003', 'q00002', 4, 1);
+
+INSERT INTO `student_course`(`Cno`, `Sno`) VALUES ('c0001', 'student1');
+INSERT INTO `student_course`(`Cno`, `Sno`) VALUES ('c0001', 'student1_en');
+INSERT INTO `student_course`(`Cno`, `Sno`) VALUES ('c0004', 'student2');
+INSERT INTO `student_course`(`Cno`, `Sno`) VALUES ('c0001', 'student3');
+INSERT INTO `student_course`(`Cno`, `Sno`) VALUES ('c0004', 'student3');
+INSERT INTO `student_course`(`Cno`, `Sno`) VALUES ('c0003', 'student4_en');
+
+INSERT INTO `test`(`Tno`, `Tname`, `Tstart`, `Tend`, `Pno`, `Cno`) VALUES ('t0001', '数据库期末考试', '2020-12-15 15:57:42', '2020-12-15 15:57:42', 'p0002', 'c0001');
+INSERT INTO `test`(`Tno`, `Tname`, `Tstart`, `Tend`, `Pno`, `Cno`) VALUES ('t0003', '流体力学期中考试', '2020-12-18 15:00:00', '2020-12-19 15:00:00', 'p0003', 'c0004');
+
+INSERT INTO `student_test`(`Tno`, `Sno`, `STgrade`) VALUES ('t0001', 'student1', NULL);
+INSERT INTO `student_test`(`Tno`, `Sno`, `STgrade`) VALUES ('t0001', 'student1_en', 95);
+INSERT INTO `student_test`(`Tno`, `Sno`, `STgrade`) VALUES ('t0001', 'student3', 78);
+INSERT INTO `student_test`(`Tno`, `Sno`, `STgrade`) VALUES ('t0003', 'student2', NULL);
+INSERT INTO `student_test`(`Tno`, `Sno`, `STgrade`) VALUES ('t0003', 'student3', NULL);

--- a/sql/data.sql
+++ b/sql/data.sql
@@ -1,3 +1,8 @@
+-- ----------------------------
+-- 含有密码字段的表均加入了两种记录：未加密版本和MD5加密版本
+-- 且密码均为123456
+-- 用于支持系统开发的不同阶段的测试工作
+-- ----------------------------
 INSERT INTO `admin`(`Ano`, `Apassword`) VALUES ('admin', '123456');
 INSERT INTO `admin`(`Ano`, `Apassword`) VALUES ('admin_en', 'e10adc3949ba59abbe56e057f20f883e');
 

--- a/sql/exam.sql
+++ b/sql/exam.sql
@@ -10,7 +10,7 @@ Target Server Type    : MYSQL
 Target Server Version : 80021
 File Encoding         : 65001
 
-Date: 2020-12-15 10:59:31
+Date: 2020-12-16 09:34:36
 */
 
 SET FOREIGN_KEY_CHECKS=0;
@@ -20,127 +20,127 @@ SET FOREIGN_KEY_CHECKS=0;
 -- ----------------------------
 DROP TABLE IF EXISTS `admin`;
 CREATE TABLE `admin` (
-  `Ano` varchar(20) NOT NULL COMMENT '管理员账号',
-  `Apassword` varchar(32) NOT NULL COMMENT '管理员密码',
+  `Ano` varchar(20) COLLATE utf8mb4_general_ci NOT NULL COMMENT '管理员账号',
+  `Apassword` varchar(32) COLLATE utf8mb4_general_ci NOT NULL COMMENT '管理员密码',
   PRIMARY KEY (`Ano`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for course
 -- ----------------------------
 DROP TABLE IF EXISTS `course`;
 CREATE TABLE `course` (
-  `Cno` varchar(20) NOT NULL COMMENT '课程编号',
-  `Cname` varchar(20) NOT NULL COMMENT '课程名称',
+  `Cno` varchar(20) COLLATE utf8mb4_general_ci NOT NULL COMMENT '课程编号',
+  `Cname` varchar(20) COLLATE utf8mb4_general_ci NOT NULL COMMENT '课程名称',
   `Subno` varchar(5) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '课程所属科目',
-  `Mno` varchar(20) DEFAULT NULL COMMENT '教授该课程教师号',
+  `Mno` varchar(20) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '教授该课程教师号',
   PRIMARY KEY (`Cno`),
   KEY `Mno` (`Mno`),
   KEY `Subno` (`Subno`),
   CONSTRAINT `course_ibfk_1` FOREIGN KEY (`Mno`) REFERENCES `mentor` (`Mno`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `course_ibfk_2` FOREIGN KEY (`Subno`) REFERENCES `subject` (`Subno`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for mentor
 -- ----------------------------
 DROP TABLE IF EXISTS `mentor`;
 CREATE TABLE `mentor` (
-  `Mno` varchar(20) NOT NULL COMMENT '教师编号',
-  `Mname` varchar(10) NOT NULL COMMENT '教师姓名',
-  `Mgender` varchar(3) DEFAULT NULL COMMENT '教师性别',
-  `Mtitle` varchar(10) DEFAULT NULL COMMENT '教师职称',
-  `Mpassword` varchar(32) NOT NULL COMMENT '教师登陆密码',
+  `Mno` varchar(20) COLLATE utf8mb4_general_ci NOT NULL COMMENT '教师编号',
+  `Mname` varchar(10) COLLATE utf8mb4_general_ci NOT NULL COMMENT '教师姓名',
+  `Mgender` varchar(3) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '教师性别',
+  `Mtitle` varchar(10) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '教师职称',
+  `Mpassword` varchar(32) COLLATE utf8mb4_general_ci NOT NULL COMMENT '教师登陆密码',
   PRIMARY KEY (`Mno`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for paper
 -- ----------------------------
 DROP TABLE IF EXISTS `paper`;
 CREATE TABLE `paper` (
-  `Pno` varchar(20) NOT NULL COMMENT '试卷的编号',
-  `Pname` varchar(30) DEFAULT NULL COMMENT '试卷名',
+  `Pno` varchar(20) COLLATE utf8mb4_general_ci NOT NULL COMMENT '试卷的编号',
+  `Pname` varchar(30) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '试卷名',
   `Subno` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '科目编号',
   `Preference` int DEFAULT '0' COMMENT '试卷被引用的次数',
   `Pisdeleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT '真：隐藏 假：显示',
   PRIMARY KEY (`Pno`),
   KEY `Subno` (`Subno`),
   CONSTRAINT `paper_ibfk_1` FOREIGN KEY (`Subno`) REFERENCES `subject` (`Subno`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for question
 -- ----------------------------
 DROP TABLE IF EXISTS `question`;
 CREATE TABLE `question` (
-  `Qno` varchar(20) NOT NULL COMMENT '题库中的编号',
-  `Qtype` enum('select', 'multi', 'fill') NOT NULL COMMENT '题目类型 select-单选 multi-多选 fill-填空',
-  `Qstem` varchar(255) NOT NULL COMMENT '题目的内容',
-  `Qanswer` varchar(255) NOT NULL COMMENT 'JSON格式的题目的答案，选择题的备选项，填空题的答案',
-  `Qselect` varchar(10) DEFAULT NULL COMMENT '选择题的正确选项',
+  `Qno` varchar(20) COLLATE utf8mb4_general_ci NOT NULL COMMENT '题库中的编号',
+  `Qtype` enum('select','multi','fill') COLLATE utf8mb4_general_ci NOT NULL COMMENT '题目类型 select-单选 multi-多选 fill-填空',
+  `Qstem` varchar(255) COLLATE utf8mb4_general_ci NOT NULL COMMENT '题目的内容',
+  `Qanswer` varchar(255) COLLATE utf8mb4_general_ci NOT NULL COMMENT 'JSON格式的题目的答案，选择题的备选项，填空题的答案',
+  `Qselect` varchar(10) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '选择题的正确选项',
   `Subno` varchar(5) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '题目所属的科目',
   `Qreference` int unsigned NOT NULL DEFAULT '0' COMMENT '题目被引用的次数',
   `Qisdeleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT '真：隐藏 假：显示',
   PRIMARY KEY (`Qno`),
   KEY `Subno` (`Subno`),
   CONSTRAINT `question_ibfk_1` FOREIGN KEY (`Subno`) REFERENCES `subject` (`Subno`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for question_paper
 -- ----------------------------
 DROP TABLE IF EXISTS `question_paper`;
 CREATE TABLE `question_paper` (
-  `Pno` varchar(20) NOT NULL COMMENT '题库中的编号',
-  `Qno` varchar(20) NOT NULL COMMENT '试卷的编号',
+  `Pno` varchar(20) COLLATE utf8mb4_general_ci NOT NULL COMMENT '题库中的编号',
+  `Qno` varchar(20) COLLATE utf8mb4_general_ci NOT NULL COMMENT '试卷的编号',
   `QPscore` int DEFAULT '0' COMMENT '试题的分值',
   `QPposition` int DEFAULT NULL COMMENT '题目在试卷中的位置',
   PRIMARY KEY (`Pno`,`Qno`),
   KEY `Qno` (`Qno`),
   CONSTRAINT `question_paper_ibfk_1` FOREIGN KEY (`Pno`) REFERENCES `paper` (`Pno`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `question_paper_ibfk_2` FOREIGN KEY (`Qno`) REFERENCES `question` (`Qno`) ON DELETE RESTRICT ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for student
 -- ----------------------------
 DROP TABLE IF EXISTS `student`;
 CREATE TABLE `student` (
-  `Sno` varchar(20) NOT NULL COMMENT '学生编号',
-  `Sname` varchar(10) NOT NULL COMMENT '学生姓名',
+  `Sno` varchar(20) COLLATE utf8mb4_general_ci NOT NULL COMMENT '学生编号',
+  `Sname` varchar(10) COLLATE utf8mb4_general_ci NOT NULL COMMENT '学生姓名',
   `Sgender` enum('男','女') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '学生性别',
-  `Smajor` varchar(20) DEFAULT NULL COMMENT '学生专业',
-  `Spassword` varchar(32) NOT NULL COMMENT '学生登陆密码',
+  `Smajor` varchar(20) COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '学生专业',
+  `Spassword` varchar(32) COLLATE utf8mb4_general_ci NOT NULL COMMENT '学生登陆密码',
   PRIMARY KEY (`Sno`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for student_course
 -- ----------------------------
 DROP TABLE IF EXISTS `student_course`;
 CREATE TABLE `student_course` (
-  `Cno` varchar(20) NOT NULL COMMENT '课程编号',
-  `Sno` varchar(20) NOT NULL COMMENT '学生编号',
+  `Cno` varchar(20) COLLATE utf8mb4_general_ci NOT NULL COMMENT '课程编号',
+  `Sno` varchar(20) COLLATE utf8mb4_general_ci NOT NULL COMMENT '学生编号',
   PRIMARY KEY (`Cno`,`Sno`),
   KEY `student_course_ibfk_2` (`Sno`),
   CONSTRAINT `student_course_ibfk_1` FOREIGN KEY (`Cno`) REFERENCES `course` (`Cno`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `student_course_ibfk_2` FOREIGN KEY (`Sno`) REFERENCES `student` (`Sno`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for student_test
 -- ----------------------------
 DROP TABLE IF EXISTS `student_test`;
 CREATE TABLE `student_test` (
-  `Tno` varchar(20) NOT NULL COMMENT '考试编号',
-  `Sno` varchar(20) NOT NULL COMMENT '学生编号',
+  `Tno` varchar(20) COLLATE utf8mb4_general_ci NOT NULL COMMENT '考试编号',
+  `Sno` varchar(20) COLLATE utf8mb4_general_ci NOT NULL COMMENT '学生编号',
   `STgrade` int DEFAULT NULL COMMENT '学生考试成绩',
   PRIMARY KEY (`Tno`,`Sno`),
   KEY `Sno` (`Sno`),
-  CONSTRAINT `student_test_ibfk_1` FOREIGN KEY (`Tno`) REFERENCES `test` (`Tno`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `student_test_ibfk_2` FOREIGN KEY (`Sno`) REFERENCES `student` (`Sno`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
+  CONSTRAINT `student_test_ibfk_1` FOREIGN KEY (`Sno`) REFERENCES `student` (`Sno`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `student_test_ibfk_2` FOREIGN KEY (`Tno`) REFERENCES `test` (`Tno`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for subject
@@ -150,22 +150,35 @@ CREATE TABLE `subject` (
   `Subno` varchar(5) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT '科目编号',
   `Subname` varchar(25) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT '科目名称',
   PRIMARY KEY (`Subno`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- ----------------------------
 -- Table structure for test
 -- ----------------------------
 DROP TABLE IF EXISTS `test`;
 CREATE TABLE `test` (
-  `Tno` char(20) NOT NULL COMMENT '考试的编号',
+  `Tno` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT '考试的编号',
   `Tname` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT '考试的名称',
   `Tstart` timestamp NOT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '考试开始时间',
   `Tend` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '考试结束时间',
-  `Pno` varchar(20) NOT NULL COMMENT '引用的试卷编号',
+  `Pno` varchar(20) COLLATE utf8mb4_general_ci NOT NULL COMMENT '引用的试卷编号',
   `Cno` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '所属的课程编号',
   PRIMARY KEY (`Tno`),
   KEY `Pno` (`Pno`),
   KEY `Cno` (`Cno`),
   CONSTRAINT `test_ibfk_1` FOREIGN KEY (`Pno`) REFERENCES `paper` (`Pno`) ON DELETE RESTRICT ON UPDATE CASCADE,
   CONSTRAINT `test_ibfk_2` FOREIGN KEY (`Cno`) REFERENCES `course` (`Cno`) ON DELETE RESTRICT ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+DROP TRIGGER IF EXISTS `qr_delete`;
+DELIMITER ;;
+CREATE TRIGGER `qr_delete` AFTER DELETE ON `question_paper` FOR EACH ROW BEGIN
+	DECLARE ref_count INT;
+	DECLARE hidden TINYINT(1);
+	UPDATE question SET Qreference = Qreference - 1 WHERE question.Qno = OLD.Qno;
+	SELECT Qreference, Qisdeleted INTO ref_count, hidden FROM question WHERE question.Qno = OLD.Qno;
+	IF ref_count = 0 AND hidden = TRUE THEN
+		DELETE FROM question WHERE question.Qno = OLD.Qno;
+	END IF;
+END
+;;
+DELIMITER ;

--- a/sql/exam.sql
+++ b/sql/exam.sql
@@ -61,9 +61,9 @@ DROP TABLE IF EXISTS `paper`;
 CREATE TABLE `paper` (
   `Pno` varchar(20) NOT NULL COMMENT '试卷的编号',
   `Pname` varchar(30) DEFAULT NULL COMMENT '试卷名',
+  `Subno` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '科目编号',
   `Preference` int DEFAULT '0' COMMENT '试卷被引用的次数',
   `Pisdeleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT '真：隐藏 假：显示',
-  `Subno` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '科目编号',
   PRIMARY KEY (`Pno`),
   KEY `Subno` (`Subno`),
   CONSTRAINT `paper_ibfk_1` FOREIGN KEY (`Subno`) REFERENCES `subject` (`Subno`) ON DELETE SET NULL ON UPDATE CASCADE
@@ -161,7 +161,7 @@ CREATE TABLE `test` (
   `Tname` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT '考试的名称',
   `Tstart` timestamp NOT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '考试开始时间',
   `Tend` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP COMMENT '考试结束时间',
-  `Pno` varchar(20) DEFAULT NULL COMMENT '引用的试卷编号',
+  `Pno` varchar(20) NOT NULL COMMENT '引用的试卷编号',
   `Cno` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL COMMENT '所属的课程编号',
   PRIMARY KEY (`Tno`),
   KEY `Pno` (`Pno`),

--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -1,0 +1,46 @@
+DELIMITER $
+CREATE TRIGGER qr_delete AFTER DELETE ON question_paper
+FOR EACH ROW
+BEGIN
+	DECLARE ref_count INT;
+	DECLARE hidden TINYINT(1);
+	UPDATE question SET Qreference = Qreference - 1 WHERE question.Qno = OLD.Qno;
+	SELECT Qreference, Qisdeleted INTO ref_count, hidden FROM question WHERE question.Qno = OLD.Qno;
+	IF ref_count = 0 AND hidden = TRUE THEN
+		DELETE FROM question WHERE question.Qno = OLD.Qno;
+	END IF;
+END;$
+
+CREATE TRIGGER qr_insert AFTER INSERT ON question_paper
+FOR EACH ROW
+BEGIN
+	UPDATE question SET Qreference = Qreference + 1 WHERE question.Qno = NEW.Qno;
+END;$
+
+-- 由于级联删除并不会激活触发器
+-- 所以通过paper上触发器间接触发
+CREATE TRIGGER p_delete BEFORE DELETE ON paper
+FOR EACH ROW
+BEGIN
+	DELETE FROM question_paper WHERE Pno = OLD.Pno;
+END;$
+
+CREATE TRIGGER t_delete AFTER DELETE ON test
+FOR EACH ROW
+BEGIN
+	DECLARE ref_count INT;
+	DECLARE hidden TINYINT(1);
+	UPDATE paper SET Preference = Preference - 1 WHERE paper.Pno = OLD.Pno;
+	SELECT Preference, Pisdeleted INTO ref_count, hidden FROM paper WHERE paper.Pno = OLD.Pno;
+	IF ref_count = 0 AND hidden = TRUE THEN
+		DELETE FROM paper WHERE paper.Pno = OLD.Pno;
+	END IF;
+END;$
+
+CREATE TRIGGER t_insert AFTER INSERT ON test
+FOR EACH ROW
+BEGIN
+	UPDATE paper SET Preference = Preference + 1 WHERE paper.Pno = NEW.Pno;
+END;$
+
+DELIMITER ;


### PR DESCRIPTION
## 建立测试数据库的步骤
1. 运行exam.sql，创建表结构
2. 运行triggers.sql，创建触发器
3. 运行data.sql，向表中插入测试数据

⚠️⚠️  一定要在插入数据之前创建触发器，否则会产生数据一致性问题

## 提交的修改
修改了数据库结构exam.sql
- 修改默认编码为utf8mb4，MySQL中utf8不是不完整的Unicode实现
- 将question表的Qtype字段、student表的Sgender字段改为枚举类型，实现自定义的约束
- 将question表的Qselect字段改为varchar(10)，因为需要支持多选题
- 将subject表的Subno字段缩短为varchar(5)
- 将admin、mentor和student中密码字段扩充至varchar(32)以支持MD5加密后的密码
- 调换部分字段的顺序，保证各表结构的统一

向数据库增加了测试用数据data.sql
- 含有密码字段的表均加入了两种记录：未加密版本和MD5加密版本，且密码均为123456，用于支持系统开发的不同阶段的测试工作
- 各实体的编号是随意指定的，不代表最终生成id的规则

创建了触发器triggers.sql
- 使用触发器维护question和paper的引用数，并删除无用记录
- 解决级联删除不会激活触发器的问题